### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -28,7 +28,7 @@ jobs:
         run: echo "::set-output name=time::$(date +'%Y-%m-%d %H:%M')"
 
       - name: Publish to Github Packages Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           build_ts: "${{ steps.current-time.outputs.time }}"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore